### PR TITLE
Add getters  for the kernel router to get the route object, dispatcher o...

### DIFF
--- a/src/WebKernelDispatcher.php
+++ b/src/WebKernelDispatcher.php
@@ -93,6 +93,20 @@ class WebKernelDispatcher
 
     /**
      *
+     * Magic get for read-only properties.
+     *
+     * @param string $key The property name.
+     *
+     * @return mixed The property.
+     *
+     */
+    public function __get($key)
+    {
+        return $this->$key;
+    }
+
+    /**
+     *
      * Logs the action to be dispatched to.
      *
      * @param mixed $action The action to be dispatched to.

--- a/src/WebKernelRouter.php
+++ b/src/WebKernelRouter.php
@@ -92,6 +92,21 @@ class WebKernelRouter
 
     /**
      *
+     * Magic get for read-only properties.
+     *
+     * @param string $key The property name.
+     *
+     * @return mixed The property.
+     *
+     */
+    public function __get($key)
+    {
+        return $this->$key;
+    }
+
+
+    /**
+     *
      * Gets the path from the URL.
      *
      * @return string


### PR DESCRIPTION
...bject etc

This helps to get the objects when I am using the https://github.com/cocoframework/web-kernel which is no longer a fork, but have a different Kernel which has the signal injected and which make use of the rest of the classes.
